### PR TITLE
fix: [sc-118327] Library upload broken

### DIFF
--- a/src/libcontribute.js
+++ b/src/libcontribute.js
@@ -85,7 +85,7 @@ export class LibraryContributor extends EventEmitter {
 	 * Creates a tar.gz stream containing the contents of the given directory in the file system that can be piped to another stream.
 	 * @param {string} dir The directory to tar.gz
 	 * @param {Array.<string>} whitelist The files to include in the library.
-	 * @returns {ReadableStream} a stream that can be piped to a writableStream to provide the tar.gz file.
+	 * @returns {string} a filename of the tar.gz file
 	 */
 	_targzdir(dir, whitelist) {
 		return new Promise((fulfill, reject) => {
@@ -102,8 +102,7 @@ export class LibraryContributor extends EventEmitter {
 			pack.pipe(gzip).pipe(archiveWriter);
 
 			archiveWriter.on('finish', () => {
-				const archiveReader = fs.createReadStream(archive.name);
-				fulfill(archiveReader);
+				fulfill(archive.name);
 			});
 
 			archiveWriter.on('error', reject);
@@ -208,8 +207,8 @@ export class LibraryContributor extends EventEmitter {
 	 * @private
 	 */
 	_buildContributePromise(libraryDirectory, libraryName, libraryWhitelist, dryRun) {
-		return Promise.resolve(this._targzdir(libraryDirectory, libraryWhitelist))
-			.then(pipe => dryRun ? true : this._contribute(libraryName, pipe));
+		return this._targzdir(libraryDirectory, libraryWhitelist)
+			.then(archiveName => dryRun ? true : this._contribute(libraryName, fs.createReadStream(archiveName)));
 	}
 }
 

--- a/test/libcontribute.spec.js
+++ b/test/libcontribute.spec.js
@@ -44,14 +44,14 @@ describe('LibraryContributor', () => {
 		});
 
 		it('tars the directory and contributes', () => {
-			const pipe = 'pipe';
-			sut._targzdir = sinon.stub().resolves(pipe);
+			const archiveName = 'archive.tar.gz';
+			sut._targzdir = sinon.stub().resolves(archiveName);
 			sut._contribute = sinon.stub();
 			const dryRun = false;
 			const exercise = sut._buildContributePromise(libraryDirectory, libraryName, dryRun);
 			const validate = () => {
 				expect(sut._targzdir).to.be.calledWith(libraryDirectory);
-				expect(sut._contribute).to.have.been.calledWith(libraryName, pipe);
+				expect(sut._contribute).to.have.been.calledWith(libraryName);
 			};
 			return exercise.then(validate);
 		});
@@ -338,7 +338,8 @@ describe('LibraryContributor', () => {
 			Object.keys(files).forEach((key) => createFile(tmpdir, key, files[key]));
 			const sut = new LibraryContributor({}, {});
 			return sut._targzdir(tmpdir, ['*.cpp', '*.h', 'license', '.gitignore'])
-				.then((stream) => {
+				.then((archiveName) => {
+					const stream = fs.createReadStream(archiveName);
 					const resultdir = path.join(tmpdir, 'result');
 					fs.mkdirSync(resultdir);
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/118327

Work around the issue of `archiveReader` stream not sending data in `particle library upload` by creating the read stream a bit later in the upload code.

Tests pass locally.