### PR TITLE
Rely on LICENSE text at the top of the repo rather than license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2025 Particle Industries, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/integration/librepo_build.integration.js
+++ b/integration/librepo_build.integration.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 /**
  * Tests for real the Agent class using an external service.
  */

--- a/integration/librepo_cloud.integration.js
+++ b/integration/librepo_cloud.integration.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 /**
  * Tests against the cloud API using particle-api-js
  */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/particle-iot/particle-library-manager"
   },
-  "license": "LGPL-3.0",
+  "license": "Apache-2.0",
   "keywords": [
     "particle",
     "cli",

--- a/src/libinit.js
+++ b/src/libinit.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { validateField } from './validation';
 import { processTemplate } from './util/template_processor';
 import * as os from 'os';

--- a/src/librepo.js
+++ b/src/librepo.js
@@ -1,24 +1,4 @@
 /*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
-
-/*
  * Welcome To
  *
  *    dP       oodP                                       8888ba.88ba

--- a/src/librepo_build.js
+++ b/src/librepo_build.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { AbstractLibraryRepository, LibraryNotFoundError, MemoryLibraryFile, AbstractLibrary } from './librepo';
 import Agent from 'particle-api-js/lib/Agent';
 import { LibraryFormatError } from './librepo';

--- a/src/librepo_cloud.js
+++ b/src/librepo_cloud.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import Particle from 'particle-api-js';
 
 import { AbstractLibraryRepository, AbstractLibrary } from './librepo';

--- a/src/librepo_fs.js
+++ b/src/librepo_fs.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { LibraryNotFoundError, LibraryRepositoryError } from './librepo';
 import VError from 'verror';
 import { LibraryContributor } from './libcontribute';

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import klaw from 'klaw';
 import path from 'path';
 

--- a/test/dependency_resolver.spec.js
+++ b/test/dependency_resolver.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 describe('DependencyResolver', () => {
 
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { expect } from './test-setup';
 import * as index from '../src/index';
 const fs = require('fs');

--- a/test/libinit.spec.js
+++ b/test/libinit.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { expect, sinon } from './test-setup';
 
 const fs = require('fs');

--- a/test/librepo.spec.js
+++ b/test/librepo.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { LibraryNotFoundError, LibraryRepositoryError, LibraryFormatError } from '../src/librepo';
 import { LibraryRepository, Library, LibraryFile, MemoryLibraryFile } from '../src/librepo';
 import { AbstractLibrary, AbstractLibraryRepository } from '../src/librepo';

--- a/test/librepo_build.spec.js
+++ b/test/librepo_build.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { sinon, expect } from './test-setup';
 
 import { BuildLibraryRepository, BuildLibrary } from '../src/librepo_build';

--- a/test/librepo_cloud.spec.js
+++ b/test/librepo_cloud.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const fs = require('fs');
 const path = require('path');
 const mockfs = require('mock-fs');

--- a/test/librepo_fs.spec.js
+++ b/test/librepo_fs.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { expect, sinon } from './test-setup';
 import { FileSystemNamingStrategy, FileSystemLibraryRepository, isLibraryExample } from '../src/librepo_fs';
 import { LibraryContributor } from '../src/libcontribute';

--- a/test/librepo_fs_mock.spec.js
+++ b/test/librepo_fs_mock.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { expect, sinon } from './test-setup';
 import concat from 'concat-stream';
 import { AbstractLibrary } from '../src/librepo';

--- a/test/validation.spec.js
+++ b/test/validation.spec.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 import { expect } from './test-setup';
 import { validateField, validateMetadata, validateLibrary } from '../src/validation';
 import { FileSystemLibraryRepository, FileSystemNamingStrategy } from '../src/librepo_fs';


### PR DESCRIPTION
Since the initial commit of this repo https://github.com/particle-iot/particle-library-manager/commit/3c2250c38294f4bd29c54574781106ba854dc89c the license has been Apache 2.0, but there were some files with comment headers with different language. The package.json also incorrectly listed LGPL-3.0.

This PR completes the intent of the initial commit that the LICENSE file at the top of the repo should define the text of the license for all the files in the repo rather than some files having separate license headers.